### PR TITLE
Initial implementation of GeoIP placeholders

### DIFF
--- a/src/components/teaser/teaser.js
+++ b/src/components/teaser/teaser.js
@@ -5,6 +5,7 @@ import Video from '../video';
 import Image from '../image';
 import { Link } from 'react-router-dom';
 import { AppContext } from '../../utils/context';
+import {TextWithPlaceholders} from '../../utils/placeholders';
 import { LinkManager } from '../../utils';
 import './teaser.css';
 
@@ -51,7 +52,7 @@ const Teaser = ({ content, config }) => {
 
 
             {content.description && content.style === 'featured' && (
-              <p itemProp='description' itemType='text'>{content.description.plaintext}</p>
+              <p itemProp='description' itemType='text'><TextWithPlaceholders>{content.description.plaintext}</TextWithPlaceholders></p>
             )}
 
             {content.callToAction && content.callToActionLink && content.style === 'featured' && (

--- a/src/utils/context.js
+++ b/src/utils/context.js
@@ -4,7 +4,7 @@ const accessToken = 'https://20409-gqldemo202212-stage.adobeioruntime.net/api/v1
 const defaultEndpoint = '/content/_cq_graphql/aem-demo-assets/endpoint.json';
 const defaultProject = 'gql-demo-template';
 const defaultServiceURL = 'https://author-p91555-e868145.adobeaemcloud.com/';
-const defaultPlaceholdersExtensionURL = 'https://1154643-geoipplaceholders.adobeio-static.net/api/v1/web/wknd-placeholders';
+const defaultPlaceholdersExtensionURL = 'https://1154643-geoipplaceholders.adobeio-static.net/api/v1/web/geoip-placeholders';
 
 export const AppContext = createContext({
   auth: sessionStorage.auth || '',

--- a/src/utils/context.js
+++ b/src/utils/context.js
@@ -4,6 +4,7 @@ const accessToken = 'https://20409-gqldemo202212-stage.adobeioruntime.net/api/v1
 const defaultEndpoint = '/content/_cq_graphql/aem-demo-assets/endpoint.json';
 const defaultProject = 'gql-demo-template';
 const defaultServiceURL = 'https://author-p91555-e868145.adobeaemcloud.com/';
+const defaultPlaceholdersExtensionURL = 'https://1154643-geoipplaceholders.adobeio-static.net/api/v1/web/wknd-placeholders';
 
 export const AppContext = createContext({
   auth: sessionStorage.auth || '',
@@ -12,6 +13,7 @@ export const AppContext = createContext({
   serviceURL: localStorage.serviceURL || defaultServiceURL,
   accessToken: accessToken,
   defaultServiceURL: defaultServiceURL,
+  placeholdersExtensionURL: localStorage.placeholdersExtensionURL || defaultPlaceholdersExtensionURL,
 });
 
 

--- a/src/utils/placeholders/index.js
+++ b/src/utils/placeholders/index.js
@@ -1,0 +1,49 @@
+import { useState, useEffect, useContext } from 'react';
+import { AppContext } from '../context';
+
+export function TextWithPlaceholders({ children }) {
+  const [text, setText] = useState(children);
+
+  const context = useContext(AppContext);
+
+  useEffect(() => {
+    (async () => {
+      const placeholders = await Promise.all(
+        [...text.matchAll(/{(.*?)}/g)].map(async (match) => {
+          const key = match[1];
+          let val = key;
+          try {
+            const placeholdersServiceEndpoint =
+            `${context.placeholdersExtensionURL}/values`;
+            const resp = await fetch(
+              `${placeholdersServiceEndpoint}?placeholder=${key}`
+            );
+            if (!resp.ok) {
+              throw new Error('Placeholder service failure');
+            }
+            val = (await resp.json()).data;
+          } catch (err) {
+            console.error(
+              `Failed to fetch value for placeholder "${key}": ${err.message}`
+            );
+          }
+          return { key, val };
+        })
+      );
+
+      let processedText = text;
+      placeholders.forEach(
+        (placeholder) => {
+          processedText = processedText.replace(
+            `{${placeholder.key}}`,
+            placeholder.val
+          );
+        },
+        [setText]
+      );
+      setText(processedText);
+    })();
+  }, [context.placeholdersExtensionURL, text]);
+
+  return text;
+}

--- a/src/utils/settings/placeholdersExtensionURL.md
+++ b/src/utils/settings/placeholdersExtensionURL.md
@@ -1,0 +1,3 @@
+## Placeholder Extension URL 
+
+Please enter the URL to your instance of GeoIP Placeholders Extension API after you deployed it to your Adobe I/O Runtime.

--- a/src/utils/settings/settings.js
+++ b/src/utils/settings/settings.js
@@ -7,6 +7,7 @@ import projectmd from './project.md';
 import authmd from './auth.md';
 import proxymd from './proxymd.md';
 import intromd from './intro.md';
+import placeholdersExtensionURLmd from './placeholdersExtensionURL.md';
 import { useErrorHandler } from 'react-error-boundary';
 import PropTypes from 'prop-types';
 import { prepareRequest } from '../index';
@@ -20,7 +21,8 @@ const instructionsData = {
   'authenticate': 'My error message',
   'project': projectmd,
   'publish': projectmd,
-  'proxy': proxymd
+  'proxy': proxymd,
+  'placeholdersExtensionURL': placeholdersExtensionURLmd,
 };
 
 const Settings = () => {
@@ -33,6 +35,7 @@ const Settings = () => {
   const [serviceURL, setServiceURL] = useState(context.serviceURL);
   const [config, setConfig] = useState({});
   const [statusCode, setStatusCode] = useState('');
+  const [placeholdersExtensionURL, setPlaceholdersExtensionURL] = useState(context.placeholdersExtensionURL);
   const configPath = `/content/dam/${project}/site/configuration/configuration`;
 
   let inFrame = false;
@@ -168,6 +171,16 @@ const Settings = () => {
                   onSelect={(e) => setInstructions(instructionsData[e.target.name])}
                   value={drNumber}
                   onChange={(e) => setDRNumber(e.target.value)}></input>
+              </label>
+              <label>Placeholders Extension URL
+                <input className='placeholders-extension-url'
+                  type='text'
+                  placeholder='Enter the URL of your placeholders extension'
+                  name='placeholdersExtensionURL'
+                  onSelect={(e) => setInstructions(instructionsData[e.target.name])}
+                  value={placeholdersExtensionURL}
+                  onChange={(e) => setPlaceholdersExtensionURL(e.target.value)}>
+                </input>
               </label>
               <button className='button'
                 type='button'


### PR DESCRIPTION
This change adds integration with [GeoIP UI Extension](https://github.com/adobe/aem-uix-examples/tree/geoip-placeholders/geoip-placeholders) that allows embedding location placeholders into the text of the headless WKND site and provides an API endpoint to get values for a user when the site is viewed.

<img width="665" alt="Screenshot 2023-08-17 at 3 52 23 PM" src="https://github.com/lamontacrook/aem-pure-headless/assets/1295148/a34b5bfb-8b76-4dbe-9bf8-1a4215e0a245">

<img width="1458" alt="Screenshot 2023-08-17 at 3 52 56 PM" src="https://github.com/lamontacrook/aem-pure-headless/assets/1295148/b5111ab6-b4b3-4558-9162-2f1afa2167aa">

Note: To enable UI Extension in CF Editor, add `devMode=true&ext=https://1154643-geoipplaceholders.adobeio-static.net/index.html` to query parameters